### PR TITLE
Removed smart contract check monitoring | OC-103

### DIFF
--- a/src/components/CourseDetails/CourseDetails.tsx
+++ b/src/components/CourseDetails/CourseDetails.tsx
@@ -1,5 +1,5 @@
 import { TonConnectButton } from '@tonconnect/ui-react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BsInfoCircleFill } from 'react-icons/bs';
 import { SiHiveBlockchain } from 'react-icons/si';
@@ -27,6 +27,7 @@ const purchaseFee = 0.07;
 function CourseDetails({ course, role }: ICourseDetailsProps) {
   const { t } = useTranslation();
   const { courseContractBalance, purchaseContractBalance } = useContract();
+  const [dataLoaded, setDataLoaded] = useState<boolean>(false);
 
   const {
     isActivateButtonDisabled,
@@ -36,11 +37,23 @@ function CourseDetails({ course, role }: ICourseDetailsProps) {
     hintMessage,
   } = useCourseActions(course, role);
 
-  const { errorContract: courseErrorContract, createCourse } =
-    useCourseContract(course, role);
+  const {
+    errorContract: courseErrorContract,
+    createCourse,
+    loading: courseLoading,
+  } = useCourseContract(course, role);
 
-  const { errorContract: purchaseErrorContract, purchaseCourse } =
-    usePurchaseContract(course, role);
+  const {
+    errorContract: purchaseErrorContract,
+    purchaseCourse,
+    loading: purchaseLoading,
+  } = usePurchaseContract(course, role);
+
+  useEffect(() => {
+    if (!courseLoading || !purchaseLoading) {
+      setDataLoaded(true);
+    }
+  }, [courseLoading, purchaseLoading]);
 
   useEffect(() => {
     if (role === USER || (role === CUSTOMER && purchaseContractBalance <= 0)) {
@@ -111,13 +124,13 @@ function CourseDetails({ course, role }: ICourseDetailsProps) {
             />
           </div>
         )}
-        {role === SELLER && (
+        {dataLoaded && role === SELLER && (
           <div className={styles.category}>
             <Label text={`${t('smart_contract_balance')}: `} isBold />
             <Label text={`${courseContractBalance} TON`} />
           </div>
         )}
-        {role === CUSTOMER && (
+        {dataLoaded && role === CUSTOMER && purchaseContractBalance > 0 && (
           <div className={styles.category}>
             <Label text={`${t('smart_contract_balance')}: `} isBold />
             <Label text={`${purchaseContractBalance} TON`} />
@@ -129,7 +142,7 @@ function CourseDetails({ course, role }: ICourseDetailsProps) {
 
       {role === SELLER && (
         <>
-          {courseContractBalance <= 0 && (
+          {dataLoaded && courseContractBalance <= 0 && (
             <div className={styles.warning}>
               {t('course_purchase_not_available')}
             </div>

--- a/src/context/ContractContext.tsx
+++ b/src/context/ContractContext.tsx
@@ -1,0 +1,45 @@
+import React, { ReactNode, createContext, useContext, useState } from 'react';
+
+interface ContractContextProps {
+  courseContractBalance: number;
+  setCourseContractBalance: React.Dispatch<React.SetStateAction<number>>;
+  purchaseContractBalance: number;
+  setPurchaseContractBalance: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const ContractContext = createContext<ContractContextProps | undefined>(
+  undefined
+);
+
+interface ContractProviderProps {
+  children: ReactNode;
+}
+
+export const ContractProvider: React.FC<ContractProviderProps> = ({
+  children,
+}: any) => {
+  const [courseContractBalance, setCourseContractBalance] = useState<number>(0);
+  const [purchaseContractBalance, setPurchaseContractBalance] =
+    useState<number>(0);
+
+  return (
+    <ContractContext.Provider
+      value={{
+        courseContractBalance,
+        setCourseContractBalance,
+        purchaseContractBalance,
+        setPurchaseContractBalance,
+      }}
+    >
+      {children}
+    </ContractContext.Provider>
+  );
+};
+
+export const useContract = (): ContractContextProps => {
+  const context = useContext(ContractContext);
+  if (!context) {
+    throw new Error('useContract must be used within a ContractProvider');
+  }
+  return context;
+};

--- a/src/context/PointsContext.tsx
+++ b/src/context/PointsContext.tsx
@@ -12,6 +12,7 @@ import { createAxiosWithAuth } from '../functions';
 interface PointsContextProps {
   points: number;
   refreshPoints: () => void;
+  setPoints: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const PointsContext = createContext<PointsContextProps | undefined>(undefined);
@@ -42,7 +43,9 @@ export const PointsProvider: React.FC<PointsProviderProps> = ({ children }) => {
   }, []);
 
   return (
-    <PointsContext.Provider value={{ points, refreshPoints: fetchPoints }}>
+    <PointsContext.Provider
+      value={{ points, setPoints, refreshPoints: fetchPoints }}
+    >
       {children}
     </PointsContext.Provider>
   );

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,3 +1,4 @@
+export { ContractProvider, useContract } from './ContractContext';
 export { ModalProvider, useModal } from './ModalContext';
 export { useNotification } from './NotificationContext';
 export { PointsProvider, usePoints } from './PointsContext';

--- a/src/hooks/useCourseContract.tsx
+++ b/src/hooks/useCourseContract.tsx
@@ -28,6 +28,7 @@ export function useCourseContract(course: ICourse, role: RoleType) {
 
   const [contractAddress, setContractAddress] = useState<string>('');
   const [errorContract, setErrorContract] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
 
   const coursePriceInNano = toNano(course.price.toString());
 
@@ -69,9 +70,11 @@ export function useCourseContract(course: ICourse, role: RoleType) {
 
   // Get contract address and balance
   const updateContractData = useCallback(async () => {
+    setLoading(true);
     const { balance, address } = await getContractData();
     setContractAddress(address);
     setCourseContractBalance(balance);
+    setLoading(false);
   }, [getContractData, setCourseContractBalance]);
 
   // Send data to backend to monitor contract status
@@ -80,7 +83,7 @@ export function useCourseContract(course: ICourse, role: RoleType) {
     try {
       const axiosWithAuth = createAxiosWithAuth(initDataRaw);
       if (contractAddress) {
-        await axiosWithAuth.post<any>('/ton/monitor', {
+        await axiosWithAuth.post('/ton/monitor', {
           contractAddress,
           courseId,
           initialBalance: courseContractBalance,
@@ -106,6 +109,7 @@ export function useCourseContract(course: ICourse, role: RoleType) {
   return {
     errorContract,
     contractAddress,
+    loading,
     createCourse: async () => {
       const message: NewCourse = {
         courseId,

--- a/src/hooks/usePurchaseContract.tsx
+++ b/src/hooks/usePurchaseContract.tsx
@@ -2,11 +2,11 @@ import { retrieveLaunchParams } from '@tma.js/sdk';
 import { Address, OpenedContract, fromNano, toNano } from '@ton/core';
 import { useCallback, useEffect, useState } from 'react';
 import TonWeb from 'tonweb';
-import { useModal } from '../context';
+import { useContract } from '../context';
+import { createAxiosWithAuth } from '../functions';
 import { NewPurchase, Purchase } from '../ton/wrappers/Purchase';
-import { ICourse, RoleType } from '../types';
+import { DeployEnum, ICourse, RoleType } from '../types';
 import { useAsyncInitialize } from './useAsyncInitialize';
-import { useCourseActions } from './useCourseActions';
 import { useTonClient } from './useTonClient';
 import { useTonConnect } from './useTonConnect';
 
@@ -23,32 +23,28 @@ export function usePurchaseContract(course: ICourse, role: RoleType) {
   const courseId = course.id;
   const { client } = useTonClient();
   const { sender } = useTonConnect(course);
-  const { showModal } = useModal();
-  const { initData } = retrieveLaunchParams();
+  const { initDataRaw, initData } = retrieveLaunchParams();
+  const { purchaseContractBalance, setPurchaseContractBalance } = useContract();
 
   const [customerId, setCustomerId] = useState<any>(0);
-  const [balance, setBalance] = useState<string>('0');
-  const [purchaseContractAddress, setPurchaseContractAddress] =
-    useState<string>('');
+  const [contractAddress, setContractAddress] = useState<string>('');
   const [errorContract, setErrorContract] = useState<string>('');
-
-  const { handlePurchaseCourse } = useCourseActions(course, role);
 
   const coursePriceInNano = toNano(course.price.toString());
 
   // Deployed purchase contract
   const purchaseDefaultContract = useAsyncInitialize(async () => {
     if (!client) return;
-    const contractAddress: any = Address.parse(
+    const address: any = Address.parse(
       process.env.REACT_APP_PURCHASE_CONTRACT_ADDRESS || ''
     );
 
-    const contract = await Purchase.fromAddress(contractAddress);
+    const contract = await Purchase.fromAddress(address);
     return client.open(contract) as OpenedContract<Purchase>;
   }, [client]);
 
   // Purchase contract with new data
-  const getPurchaseContractBalance = useCallback(async () => {
+  const getContractData = useCallback(async () => {
     try {
       const contractByData = await Purchase.fromInit(
         courseId,
@@ -56,67 +52,73 @@ export function usePurchaseContract(course: ICourse, role: RoleType) {
         BigInt(course.userId),
         BigInt(initData?.user?.id || '')
       );
-      const contractAddress = contractByData.address.toString();
-      setPurchaseContractAddress(contractAddress);
-      const balanceInfo = await tonweb.provider.getBalance(contractAddress);
-      return balanceInfo;
-    } catch (error) {
-      return '0';
+      const address = contractByData.address.toString();
+      const balanceInNano = await tonweb.provider.getBalance(address);
+      const balance = parseFloat(fromNano(balanceInNano));
+
+      return {
+        balance,
+        address,
+      };
+    } catch (error: any) {
+      setErrorContract(error?.message);
+      return {
+        balance: 0,
+        address: '',
+      };
     }
     // eslint-disable-next-line
   }, [courseId, coursePriceInNano, course.userId]);
 
-  const updateBalance = useCallback(async () => {
-    const contractBalance = await getPurchaseContractBalance();
-    setBalance(fromNano(contractBalance));
-  }, [getPurchaseContractBalance]);
-
-  const checkAndUpdateBalance = useCallback(async () => {
-    const initialBalance = await getPurchaseContractBalance();
-    setBalance(fromNano(initialBalance));
-
-    const intervalId = setInterval(async () => {
-      const currentBalance = await getPurchaseContractBalance();
-      if (currentBalance !== initialBalance) {
-        setBalance(fromNano(currentBalance));
-
-        try {
-          await handlePurchaseCourse();
-          showModal('purchase', course.name);
-        } catch (error: any) {}
-
-        clearInterval(intervalId);
-      }
-    }, 5000); // 5 sec
-
-    // Clear the interval when unmounting a component or changing dependencies
-    return () => clearInterval(intervalId);
-  }, [
-    getPurchaseContractBalance,
-    handlePurchaseCourse,
-    showModal,
-    course.name,
-  ]);
+  const updateContractData = useCallback(async () => {
+    const { balance, address } = await getContractData();
+    setContractAddress(address);
+    setPurchaseContractBalance(balance);
+  }, [getContractData, setPurchaseContractBalance]);
 
   useEffect(() => {
     setCustomerId(initData?.user?.id);
   }, [initData?.user?.id]);
 
+  // Send data to backend to monitor contract status
+  const monitorContract = useCallback(async () => {
+    if (!initDataRaw) return;
+    try {
+      const axiosWithAuth = createAxiosWithAuth(initDataRaw);
+      if (contractAddress) {
+        await axiosWithAuth.post<any>('/ton/monitor', {
+          contractAddress,
+          courseId,
+          initialBalance: purchaseContractBalance,
+          type: DeployEnum.Purchase,
+          language: initData?.user?.languageCode,
+        });
+      }
+    } catch (error: any) {
+      return error?.message;
+    }
+  }, [
+    initDataRaw,
+    courseId,
+    initData?.user?.languageCode,
+    purchaseContractBalance,
+    contractAddress,
+  ]);
+
   useEffect(() => {
-    updateBalance();
-  }, [updateBalance]);
+    updateContractData();
+  }, [updateContractData]);
 
   return {
     customerId,
-    balance: parseFloat(balance),
     errorContract,
-    purchaseContractAddress,
+    contractAddress,
 
-    // Send money to 2 contracts: seller contract "Sale" (useTonConnect) and create purchase contract "NewPurchase"
+    // Send money to 2 contracts: seller contract with type Sale (useTonConnect) and create purchase contract "NewPurchase"
     purchaseCourse: async () => {
       const message: NewPurchase = {
-        $$type: 'NewPurchase',
         courseId,
+        $$type: 'NewPurchase',
         coursePrice: coursePriceInNano,
         sellerId: BigInt(course.userId),
         customerId: BigInt(customerId),
@@ -129,7 +131,7 @@ export function usePurchaseContract(course: ICourse, role: RoleType) {
           },
           message
         );
-        await checkAndUpdateBalance();
+        await monitorContract();
       } catch (error: any) {
         setErrorContract(
           `Transaction failed or was rejected. ${error?.message}`

--- a/src/hooks/usePurchaseContract.tsx
+++ b/src/hooks/usePurchaseContract.tsx
@@ -29,6 +29,7 @@ export function usePurchaseContract(course: ICourse, role: RoleType) {
   const [customerId, setCustomerId] = useState<any>(0);
   const [contractAddress, setContractAddress] = useState<string>('');
   const [errorContract, setErrorContract] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
 
   const coursePriceInNano = toNano(course.price.toString());
 
@@ -71,9 +72,11 @@ export function usePurchaseContract(course: ICourse, role: RoleType) {
   }, [courseId, coursePriceInNano, course.userId]);
 
   const updateContractData = useCallback(async () => {
+    setLoading(true);
     const { balance, address } = await getContractData();
     setContractAddress(address);
     setPurchaseContractBalance(balance);
+    setLoading(false);
   }, [getContractData, setPurchaseContractBalance]);
 
   useEffect(() => {
@@ -113,6 +116,7 @@ export function usePurchaseContract(course: ICourse, role: RoleType) {
     customerId,
     errorContract,
     contractAddress,
+    loading,
 
     // Send money to 2 contracts: seller contract with type Sale (useTonConnect) and create purchase contract "NewPurchase"
     purchaseCourse: async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+// Interface
 export interface ICourse {
   id: string;
   name: string;
@@ -29,7 +30,18 @@ export interface ILesson {
   videoUrl?: string;
 }
 
+// Type
 export type EntityType = 'module' | 'lesson';
 export type RoleType = 'user' | 'customer' | 'seller';
 export type RequestMethodType = 'post' | 'patch';
 export type DeployType = 'create' | 'purchase';
+
+// Enum
+export enum StatusEnum {
+  Success = 'success',
+  Error = 'error',
+}
+export enum DeployEnum {
+  Create = 'create',
+  Purchase = 'purchase',
+}


### PR DESCRIPTION
Now as soon as a course is activated on the blockchain (Creating a Course smart contract)
or purchasing a course (Creating a smart contract Purchase)
a request is made to the backend
and checks the contract balance every 20 seconds for 5 min.
If the balance of the contract is increased,
then points are credited to the user and a notification is sent to the user.
If not increased, an error notification is sent to the user and no points are awarded.
This is done so that the user does not have to wait with a locked screen for the smart contract balance to be updated.
Since if the user would close the app, the points would not be credited.
The backend now performs this procedure in the background, unlike the frontend.

Also:
- there are now no requests (endpoints) to the backend to add points, this is done in the background;
- make display of smart contract related items only after they are loaded;