### PR TITLE
OC-127 & OC-128 | Enabling a timer & Adding an inpute to enter a code if mail is unconfirmed

### DIFF
--- a/src/hooks/useUserPage.tsx
+++ b/src/hooks/useUserPage.tsx
@@ -29,8 +29,9 @@ export function useUserPage() {
   const [showCode, setShowCode] = useState<boolean>(false);
   const [showIsVerifiedEmail, setShowIsVerifiedEmail] =
     useState<boolean>(false);
-  const [buttonResendCode, setButtonResendCode] = useState<boolean>(true);
+  const [buttonResendCode, setButtonResendCode] = useState<boolean>(false);
   const [errorPage, setErrorPage] = useState<string | null>(null);
+  let [counter, setCounter] = useState<number>(120);
 
   const queryClient = useQueryClient();
 
@@ -51,6 +52,19 @@ export function useUserPage() {
     email,
   };
 
+  const showCounter = useCallback(() => {
+    if (counter === 120) {
+      const idInterval = setInterval(() => {
+        setCounter(counter--);
+        if (counter === 0) {
+          setButtonResendCode(true);
+          setCounter(120);
+          clearInterval(idInterval);
+        }
+      }, 1000);
+    }
+  }, [counter, setCounter, setButtonResendCode]);
+
   // Mutations
   const saveDataAndGenerateCodeMutation = useMutation({
     mutationFn: () => saveDataAndGenerateCodeAPI(initDataRaw, dataToSend),
@@ -63,6 +77,7 @@ export function useUserPage() {
       } else {
         setShowIsVerifiedEmail(!isVerifiedEmail);
         setShowCode(true);
+        showCounter();
       }
       queryClient.invalidateQueries({
         queryKey: ['userDetails', initDataRaw],
@@ -140,7 +155,7 @@ export function useUserPage() {
   }, [firstName, lastName, email]);
 
   useEffect(() => {
-    if (!showCode && email !== emailFromDB) {
+    if (email !== emailFromDB || (!showCode && !showIsVerifiedEmail)) {
       tg.MainButton.setParams({
         text: t('get_code'),
         color: getCSSVariableValue('--tg-theme-button-color'),
@@ -190,6 +205,9 @@ export function useUserPage() {
     buttonResendCode,
     setButtonResendCode,
     resendCode,
+    counter,
+    setCounter,
+    showCounter,
 
     isLoading:
       isLoading ||

--- a/src/hooks/useUserPage.tsx
+++ b/src/hooks/useUserPage.tsx
@@ -32,6 +32,9 @@ export function useUserPage() {
   const [buttonResendCode, setButtonResendCode] = useState<boolean>(false);
   const [errorPage, setErrorPage] = useState<string | null>(null);
   let [counter, setCounter] = useState<number>(120);
+  const [firstNameDisabled, setFirstNameDisabled] = useState<boolean>(false);
+  const [lastNameDisabled, setLastNameDisabled] = useState<boolean>(false);
+  const [emailDisabled, setEmailDisabled] = useState<boolean>(false);
 
   const queryClient = useQueryClient();
 
@@ -78,6 +81,9 @@ export function useUserPage() {
         setShowIsVerifiedEmail(!isVerifiedEmail);
         setShowCode(true);
         showCounter();
+        setFirstNameDisabled(true);
+        setLastNameDisabled(true);
+        setEmailDisabled(true);
       }
       queryClient.invalidateQueries({
         queryKey: ['userDetails', initDataRaw],
@@ -208,6 +214,9 @@ export function useUserPage() {
     counter,
     setCounter,
     showCounter,
+    firstNameDisabled,
+    lastNameDisabled,
+    emailDisabled,
 
     isLoading:
       isLoading ||

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -26,8 +26,6 @@ function UserPage() {
     phone,
     email,
     setEmail,
-    isLoading,
-    error,
     code,
     setCode,
     showCode,
@@ -36,6 +34,11 @@ function UserPage() {
     resendCode,
     counter,
     showCounter,
+    firstNameDisabled,
+    lastNameDisabled,
+    emailDisabled,
+    isLoading,
+    error,
   } = useUserPage() as IUseUserPageReturnType;
 
   return (
@@ -48,6 +51,7 @@ function UserPage() {
         />
         <Label text={t('first_name')} isRequired isPadding isBold />
         <TextInput
+          disabled={firstNameDisabled}
           value={firstName}
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             setFirstName(event.target.value)
@@ -55,6 +59,7 @@ function UserPage() {
         />
         <Label text={t('last_name')} isPadding isBold />
         <TextInput
+          disabled={lastNameDisabled}
           value={lastName}
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             setLastName(event.target.value)
@@ -63,12 +68,13 @@ function UserPage() {
         <Label text={t('phone_number')} isPadding isBold />
         <TextInput
           disabled={true}
-          value={phone} // Connect with the data obtained from tg
+          value={phone || ' '} // Connect with the data obtained from tg
           placeholder={phone}
         />
         <Label text={t('email')} isRequired isPadding isBold />
         <TextInput
           type="email"
+          disabled={emailDisabled}
           value={email}
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             setEmail(event.target.value)

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useState } from 'react';
+import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CgBriefcase } from 'react-icons/cg';
 import { MdOutlineUpdate } from 'react-icons/md';
@@ -33,22 +33,10 @@ function UserPage() {
     showCode,
     showIsVerifiedEmail,
     buttonResendCode,
-    setButtonResendCode,
     resendCode,
+    counter,
+    showCounter,
   } = useUserPage() as IUseUserPageReturnType;
-
-  let [counter, setCounter] = useState<number>(120);
-
-  const showCouner = useCallback(() => {
-    const idInterval = setInterval(() => {
-      setCounter(counter--);
-      if (counter === 0) {
-        setButtonResendCode(true);
-        setCounter(120);
-        clearInterval(idInterval);
-      }
-    }, 1000);
-  }, [counter, setCounter, setButtonResendCode]);
 
   return (
     <Container>
@@ -104,7 +92,7 @@ function UserPage() {
               text={t('resend_code')}
               onClick={() => {
                 resendCode();
-                showCouner();
+                showCounter();
               }}
               disabled={!buttonResendCode}
             />
@@ -128,7 +116,7 @@ function UserPage() {
           <p className={styles.infoGreen}>{t('email_confirmed')}</p>
         </div>
       ) : (
-        <div className={styles.isVerif}>
+        <div className={styles.isVerifiedEmail}>
           <LazyLoadImage
             src="https://static.vecteezy.com/system/resources/previews/018/887/460/original/signs-close-icon-png.png"
             alt="cross"

--- a/src/pages/types.ts
+++ b/src/pages/types.ts
@@ -95,6 +95,9 @@ export interface IUseUserPageReturnType {
   buttonResendCode: boolean;
   setButtonResendCode: (activButton: boolean) => void;
   resendCode: () => void;
+  counter: number;
+  setCounter: (counter: number) => void;
+  showCounter: () => void;
 }
 
 export interface IUserPageParams {

--- a/src/pages/types.ts
+++ b/src/pages/types.ts
@@ -87,8 +87,6 @@ export interface IUseUserPageReturnType {
   setEmail: (email: string) => void;
   code: string;
   setCode: (code: string) => void;
-  isLoading: boolean;
-  error: string;
   showCode: boolean;
   showIsVerifiedEmail: boolean;
   setShowIsVerifiedEmail: (showIsVerifiedEmail: boolean) => void;
@@ -98,6 +96,11 @@ export interface IUseUserPageReturnType {
   counter: number;
   setCounter: (counter: number) => void;
   showCounter: () => void;
+  firstNameDisabled: boolean;
+  lastNameDisabled: boolean;
+  emailDisabled: boolean;
+  isLoading: boolean;
+  error: string;
 }
 
 export interface IUserPageParams {


### PR DESCRIPTION
Configure timer activation and deactivation of the 'resend_code' button immediately after pressing the 'send confirmation code' button. 
I didn't immediately open the confirmation code entry panel, I just changed the button to "Send confirmation code to email".
I think it looks clear and logical to me. At the same time I found a problem with timer re-enabling when changing the mail and requesting to send a new code to mail via tg.MainButton, I fixed this flaw, now everything works correctly.